### PR TITLE
Switch to float64

### DIFF
--- a/coeffs/read.go
+++ b/coeffs/read.go
@@ -33,7 +33,7 @@ type epochData struct {
 	coeffs *[]float64
 }
 
-// NewCoeffsData - returns an initialized IGRF SHC data.
+// NewCoeffsData - returns an initialized IGRF SHC data structure.
 func NewCoeffsData() (*IGRFcoeffs, error) {
 	igrf := IGRFcoeffs{data: &map[string]*epochData{}}
 	if err := igrf.readCoeffs(); err != nil {

--- a/igrf/igrf.go
+++ b/igrf/igrf.go
@@ -92,20 +92,20 @@ func IGRF(lat, lon, alt, date float64) (IGRFresults, error) {
 	// }
 
 	res := IGRFresults{
-		Declination:         float32(d),
-		DeclinationSV:       float32(ddot),
-		Inclination:         float32(i),
-		InclinationSV:       float32(idot),
-		HorizontalIntensity: float32(h),
-		HorizontalSV:        float32(hdot),
-		NorthComponent:      float32(x),
-		NorthSV:             float32(xdot),
-		EastComponent:       float32(y),
-		EastSV:              float32(ydot),
-		VerticalComponent:   float32(z),
-		VerticalSV:          float32(zdot),
-		TotalIntensity:      float32(f),
-		TotalSV:             float32(fdot),
+		Declination:         d,
+		DeclinationSV:       ddot,
+		Inclination:         i,
+		InclinationSV:       idot,
+		HorizontalIntensity: h,
+		HorizontalSV:        hdot,
+		NorthComponent:      x,
+		NorthSV:             xdot,
+		EastComponent:       y,
+		EastSV:              ydot,
+		VerticalComponent:   z,
+		VerticalSV:          zdot,
+		TotalIntensity:      f,
+		TotalSV:             fdot,
 	}
 	return res, nil
 }

--- a/igrf/igrf_test.go
+++ b/igrf/igrf_test.go
@@ -231,27 +231,21 @@ func toFloat64(str string) float64 {
 	return float64(val)
 }
 
-func toFloat32(str string) float32 {
-	val, err := strconv.ParseFloat(str, 32)
-	check(err)
-	return float32(val)
-}
-
 func getIGRFresults(line []string) IGRFresults {
 	return IGRFresults{
-		Declination:         toFloat32(line[1]),
-		DeclinationSV:       toFloat32(line[2]),
-		Inclination:         toFloat32(line[3]),
-		InclinationSV:       toFloat32(line[4]),
-		HorizontalIntensity: toFloat32(line[5]),
-		HorizontalSV:        toFloat32(line[6]),
-		NorthComponent:      toFloat32(line[7]),
-		NorthSV:             toFloat32(line[8]),
-		EastComponent:       toFloat32(line[9]),
-		EastSV:              toFloat32(line[10]),
-		VerticalComponent:   toFloat32(line[11]),
-		VerticalSV:          toFloat32(line[12]),
-		TotalIntensity:      toFloat32(line[13]),
-		TotalSV:             toFloat32(line[14]),
+		Declination:         toFloat64(line[1]),
+		DeclinationSV:       toFloat64(line[2]),
+		Inclination:         toFloat64(line[3]),
+		InclinationSV:       toFloat64(line[4]),
+		HorizontalIntensity: toFloat64(line[5]),
+		HorizontalSV:        toFloat64(line[6]),
+		NorthComponent:      toFloat64(line[7]),
+		NorthSV:             toFloat64(line[8]),
+		EastComponent:       toFloat64(line[9]),
+		EastSV:              toFloat64(line[10]),
+		VerticalComponent:   toFloat64(line[11]),
+		VerticalSV:          toFloat64(line[12]),
+		TotalIntensity:      toFloat64(line[13]),
+		TotalSV:             toFloat64(line[14]),
 	}
 }

--- a/igrf/result.go
+++ b/igrf/result.go
@@ -18,18 +18,18 @@ package igrf
 // TotalIntensity (F):  53814.3 nT
 // TotalSV (F):  71.8 nT/yr
 type IGRFresults struct {
-	Declination         float32
-	DeclinationSV       float32
-	Inclination         float32
-	InclinationSV       float32
-	HorizontalIntensity float32
-	HorizontalSV        float32
-	NorthComponent      float32
-	NorthSV             float32
-	EastComponent       float32
-	EastSV              float32
-	VerticalComponent   float32
-	VerticalSV          float32
-	TotalIntensity      float32
-	TotalSV             float32
+	Declination         float64
+	DeclinationSV       float64
+	Inclination         float64
+	InclinationSV       float64
+	HorizontalIntensity float64
+	HorizontalSV        float64
+	NorthComponent      float64
+	NorthSV             float64
+	EastComponent       float64
+	EastSV              float64
+	VerticalComponent   float64
+	VerticalSV          float64
+	TotalIntensity      float64
+	TotalSV             float64
 }


### PR DESCRIPTION
All `IGRFresults` values are of type `float64` now.