### PR TITLE
The interface changed completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/proway2/go-igrf.svg)](https://pkg.go.dev/github.com/proway2/go-igrf)
 
 # go-igrf
-Pure Go IGRF (International Geomagnetic Reference Field). This is based on the existing `C` implementation.
+Pure Go IGRF (International Geomagnetic Reference Field). This is based on the existing `C` implementation. This package computes values for the geomagnetic field and secular variation for a given set of coordinates and date.
 
 ## Inputs
 
@@ -63,8 +63,9 @@ import (
 )
 
 func main() {
-	res, _ := igrf.IGRF(46.9, 39.9, 0.0, 2021.5)
-	fmt.Println(res)
+	igrf_data := igrf.New()
+	res, err := igrf_data.IGRF(46.9, 39.9, 0.0, 2021.5)
+	fmt.Println(res, err)
 }
 ```
 

--- a/igrf/igrf.go
+++ b/igrf/igrf.go
@@ -10,6 +10,19 @@ import (
 	"github.com/proway2/go-igrf/coeffs"
 )
 
+type IGRFdata struct {
+	shc *coeffs.IGRFcoeffs
+}
+
+// New returns an initialized IGRF structure that could be used to compute .
+func New() *IGRFdata {
+	shc, err := coeffs.NewCoeffsData()
+	if err != nil {
+		log.Fatal(err.Error())
+	}
+	return &IGRFdata{shc: shc}
+}
+
 // IGRF computes values for the geomagnetic field and secular variation for a given set of coordinates and date
 // and returns a populated `IGRFresults` structure.
 //
@@ -19,15 +32,14 @@ import (
 // alt - geodetic altitude above mean sea level in km (-1.00 to 600.00).
 //
 // date - decimal date (1900.00 to 2025).
-func IGRF(lat, lon, alt, date float64) (IGRFresults, error) {
+func (igd *IGRFdata) IGRF(lat, lon, alt, date float64) (IGRFresults, error) {
+	if igd.shc == nil {
+		return IGRFresults{}, errors.New("IGRFdata structure is not initialized.")
+	}
 	if err := checkInitialConditions(lat, lon, alt); err != nil {
 		return IGRFresults{}, err
 	}
-	shc, err := coeffs.NewCoeffsData()
-	if err != nil {
-		log.Fatal(err.Error())
-	}
-	start_coeffs, end_coeffs, nmax, err := shc.Coeffs(date)
+	start_coeffs, end_coeffs, nmax, err := igd.shc.Coeffs(date)
 	if err != nil {
 		return IGRFresults{}, err
 	}

--- a/igrf/igrf_edge_test.go
+++ b/igrf/igrf_edge_test.go
@@ -61,9 +61,10 @@ func TestIGRFEdgeCases(t *testing.T) {
 		// 	wantErr: false,
 		// },
 	}
+	igrf_data := New()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IGRF(tt.args.lat, tt.args.lon, tt.args.alt, tt.args.date)
+			got, err := igrf_data.IGRF(tt.args.lat, tt.args.lon, tt.args.alt, tt.args.date)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("IGRF() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/igrf/igrf_test.go
+++ b/igrf/igrf_test.go
@@ -6,10 +6,13 @@ import (
 	"math"
 	"os"
 	"path/filepath"
+	"reflect"
 	"regexp"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/proway2/go-igrf/coeffs"
 )
 
 type args struct {
@@ -37,19 +40,41 @@ const (
 
 const near_pole_tolerance = 0.001
 
+func TestNew(t *testing.T) {
+	shc, _ := coeffs.NewCoeffsData()
+	tests := []struct {
+		name string
+		want *IGRFdata
+	}{
+		{
+			name: "Creating a IGRF data structure",
+			want: &IGRFdata{shc: shc},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := New()
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // SV fields are just integers in FORTRAN, so there might be situations where:
 // calculated value 16.47, reference 17
 // calculated value 2.52, reference 3
 // ...
 // const max_sv_error = 50 // %
 
-func TestIGRFDataCases(t *testing.T) {
+func TestIGRFdata_IGRF(t *testing.T) {
 	tests := getTestData()
+	igrf_data := New()
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := IGRF(tt.args.lat, tt.args.lon, tt.args.alt, tt.args.date)
+			got, err := igrf_data.IGRF(tt.args.lat, tt.args.lon, tt.args.alt, tt.args.date)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("IGRF() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("IGRFdata.IGRF() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			allowed_relative_error := getMaxAllowedRelativeError(tt.args.lat)


### PR DESCRIPTION
Closes #33 

Reading coeffs and the actual calculation is splitted into different parts. This speeds up the whole process significantly, but also introduces backward incompatibility. Please refer to `README.md` for how to use.
Some profiles:
- used to be 
[main.pb.gz](https://github.com/proway2/go-igrf/files/10252017/main.pb.gz)
- new results 
[new.pb.gz](https://github.com/proway2/go-igrf/files/10252022/new.pb.gz)

_These files could be opened with `go tool pprof -web <filename>`_

For the whole set of tests the speed up is x10 times.